### PR TITLE
Updating links in README for Di Cook and the original 2016 Vignette.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ Provides functions to interface with Australian Government Bureau of Meteorology
 current weather data from stations, ag information bulletins, historical weather
 data and downloading and importing radar or satellite imagery.
 
-Credit for the name, *bomrang*, goes to [Di Cook](https://dicook.github.io), who
+Credit for the name, *bomrang*, goes to [Di Cook](http://dicook.org/), who
 suggested it while attending the rOpenSci AUUnconf in Brisbane, 2016, upon
 seeing the
-[vignette](https://github.com/saundersk1/auunconf16/blob/master/Vignette_BOM.pdf)
+[vignette](https://github.com/katerobsau/auunconf16/blob/master/Vignette_BoM.pdf)
 that we had assembled during the Unconf.
 
 Quick Start


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Updating broken links in the README only.

Out of interest I was referring back to the original Vignette from the 2016 OzUnconf and noticed the link was broken in the README. I checked the other links on the README and found the Di Cook page link was also broken.  

I have updated these links directly in the `devel` branch in my fork, rather than creating a new branch given it is a minor change. I hope this is okay. Given the low-touch I have not re-documented or rebuilt the pkg. But happy to take guidance on this.

## Related Issue
NA

## Example
NA, no new tests. 
