### PR TITLE
Resolve group_by issues (#105)

### DIFF
--- a/R/bomrang_tbl.R
+++ b/R/bomrang_tbl.R
@@ -38,6 +38,11 @@ print.bomrang_tbl <- function(x, ...) {
   if (!is.null(attr(x, "vars"))) {
     .stylecat("  Groups:\t\t", vars, paste0(" [", length(indices), "]\n"))
   }
+  if (!is.null(attr(x, "groups"))) {
+    vars <- setdiff(names(attr(x, "groups")), ".rows")
+    indices <- nrow(attr(x, "groups"))
+    .stylecat("  Groups:\t\t", vars, paste0(" [", indices, "]\n"))
+  }
   .stylecat("  ", strrep("-", 63), "  \n")
   
 }

--- a/R/dplyr.R
+++ b/R/dplyr.R
@@ -3,7 +3,8 @@
 ## attributes set by bomrang which should be preserved
 .bomrang_attribs <- c("class", "station", "type", "origin", 
                       "location", "lat", "lon", "start", 
-                      "end", "years", "ncc_list", "vars", "indices")
+                      "end", "count", "units", "years", 
+                      "ncc_list", "vars", "indices", "groups")
 
 #' @export
 dplyr::filter
@@ -71,9 +72,10 @@ dplyr::group_by
 #' @inheritParams dplyr group_by
 #' @export
 group_by.bomrang_tbl <- function(.data, ...) {
-  attribs <- attributes(.data)[.bomrang_attribs]
+  attribs <- attributes(.data)[setdiff(.bomrang_attribs, "class")]
   .data <- NextMethod(.data)
   attributes(.data) <- utils::modifyList(attributes(.data), attribs)
+  attr(.data, "class") <- union(c("bomrang_tbl", "data.table", "grouped_df"), attr(.data, "class"))
   .data
 }
 


### PR DESCRIPTION
* resolve issue with group_by dropping grouped_df class
* resolve issue with count and unit not propagating to attribs
* resolve issue with group info not printing in header

As far as I can tell this resolves the `group_by` issues of #105. The `bind_rows` issue appears to be resolved by either this or by upgrading to the development version of `dplyr` (correct me if I'm wrong).

```r
Hobart %>% 
  mutate(day = as.Date(local_date_time_full)) %>%
  group_by(day) %>% 
  summarise(daily_temp = mean(air_temp))
#> # A tibble: 4 x 2
#>   day        daily_temp
#>   <date>          <dbl>
#> 1 2019-11-17       12.4
#> 2 2019-11-18       15.7
#> 3 2019-11-19       13.0
#> 4 2019-11-20       20.2
```

Groups are also once again displayed in a grouped object

```r
Hobart %>% 
  mutate(day = as.Date(local_date_time_full)) %>%
  group_by(day) 
#>   ---- Australian Bureau of Meteorology (BOM) Data Resource ----
#>   (Original Request Parameters)
#>   Station:       HOBART (ELLERSLIE ROAD) [094029] 
#>   Location:      lat: -42.8897, lon: 147.3278
#>   Measurement / Origin:  All / Current
#>   Timespan:      1882 -- 2019 [137 years]
#>   Groups:        day [4]
#>   ---------------------------------------------------------------  
```


