### PR TITLE
Fix incorrect coercion for `rel_hum` in `get_current_weather`

### DIFF
--- a/.github/workflows/update-tic.yml
+++ b/.github/workflows/update-tic.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: "[Stage] Dependencies"
         run: |
-            sudo apt install libcurl4-openssl-dev libsodium-dev
+            sudo apt install libcurl4-openssl-dev libsodium-dev libharfbuzz-dev libfribidi-dev
             Rscript -e "if (!requireNamespace('remotes')) install.packages('remotes', type = 'source')"
             Rscript -e "remotes::install_github('ropensci/tic', dependencies = TRUE)"
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# bomrang 0.7.3
+
+## Bug fixes
+
+* `get_current_weather()` now returns the correct values for `rel_hum`, rather than returning
+  a column of `NA`.
+
 # bomrang 0.7.2
 
 * Fixes an example that wrote to R userspace, when it should not in `get_radar_imagery()`

--- a/R/get_current_weather.R
+++ b/R/get_current_weather.R
@@ -280,8 +280,6 @@ get_current_weather <-
       )),
       .SDcols = "aifstime_utc"]
     
-    out[, "rel_hum" := suppressWarnings(as.integer("rel_hum"))]
-    
     # Columns which are meant to be numeric
     double_cols <-
       c("lat",


### PR DESCRIPTION

## Description
`get_currrent_weather` used `as.integer("rel_hum")` to coerce the column `rel_hum` to integer, but this attempts to coerce the string literal `"rel_hum"` which is always `NA`.  The original intent was to map strings like `"-"`` to NA but leave the others as integer. However, this is not guaranteed for other columns so the simplest fix is just to remove the offending line.


## Example

```r
# before 
head(get_current_weather("ALICE SPRINGS")$rel_hum)
#> NA NA NA NA NA NA

# now
#> 40 37 34 43 40 39   
```

I haven't included tests because sometimes the data really will be a column full of NA.




