### PR TITLE
0-pad station number in output to 6 characters

### DIFF
--- a/R/get_historical_weather.R
+++ b/R/get_historical_weather.R
@@ -176,6 +176,7 @@ get_historical_weather <- get_historical <-
                                "quality"),
                       solar = c("solar_exposure")
                     ))
+    dat[["station_number"]] <- sprintf("%06d", as.integer(dat[["station_number"]]))
     
     return(
       structure(


### PR DESCRIPTION
Per #127 the station_number column returned in `get_historical_weather()` does not match the station_id used elsewhere. The cause is the data itself where the station column is stored without leading 0s, e.g. `IDCJAC0009_023000_1800_Data.csv`.

This solution is to left-pad the station_number output with 0 to fill 6 characters. Is that the appropriate format for other station_ids?